### PR TITLE
Restrict Enum34 dependency to python 3.4 or less.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ requirements = [
     "semantic_version>=2.4,<2.7",
     "tabulate==0.7.5",
     "tqdm>=4.8.1",
+    "PyYaml==5.2",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requirements = [
     # pure-Python packages, so it shouldn't be a huge burden for users to
     # obtain them.
     "blessings>=1.6,<2",
-    "enum34>=1.1,<2",
+    'enum34>=1.1,<2;python_version<"3.4"',
     "releases>=1.6,<2",
     "semantic_version>=2.4,<2.7",
     "tabulate==0.7.5",


### PR DESCRIPTION
Resolves #17 