### PR TITLE
Improve docs portability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,140 @@
-build
+_sandbox
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
-htmlcov
+.coverage.*
 .cache
-docs/_build
+nosetests.xml
 coverage.xml
-_build
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/invocations/docs.py
+++ b/invocations/docs.py
@@ -3,8 +3,10 @@ Tasks for managing Sphinx documentation trees.
 """
 
 from os.path import join, isdir
+from pathlib import Path
 from tempfile import mkdtemp
 from shutil import rmtree
+import webbrowser
 import sys
 
 from invoke import task, Collection, Context
@@ -28,8 +30,8 @@ def _browse(c):
     """
     Open build target's index.html in a browser (using 'open').
     """
-    index = join(c.sphinx.target, c.sphinx.target_file)
-    c.run("open {0}".format(index))
+    index = Path(c.sphinx.target) / c.sphinx.target_file
+    webbrowser.open(str(index.absolute()))
 
 
 @task(


### PR DESCRIPTION
Many tasks in docs assume particular conditions on the system and the installation, that are not strictly required.

e.g.:
- the availability of `open` command for displaying html docs -> there is `webbrowser` in stdlib
- the availability of `tree` command for displaying the structure -> use `os.walk` and render with python libraries (e.g. [`rich`](https://rich.readthedocs.io/en/latest/))

I'm sure that other occurrences of this kind of issue are present in other invocations as well, but I was using `docs` in the first placed and I started fixing that one, if ever I'll try to improve also the others.

P.S.: for my personal convenience I'm also replacing the small `.gitignore` present with the standard [`Python.gitignore`](https://github.com/github/gitignore/blob/master/Python.gitignore) maintained by GitHub