### PR TITLE
refactor!: remove python2

### DIFF
--- a/invocations/console.py
+++ b/invocations/console.py
@@ -6,8 +6,6 @@ from __future__ import unicode_literals, print_function
 
 import sys
 
-from invoke.vendor.six.moves import input
-
 
 # NOTE: originally cribbed from fab 1's contrib.console.confirm
 def confirm(question, assume_yes=True):

--- a/invocations/packaging/release.py
+++ b/invocations/packaging/release.py
@@ -18,11 +18,10 @@ import re
 import sys
 from functools import partial
 from glob import glob
+from io import StringIO
 from shutil import rmtree
 
-from invoke.vendor.six import StringIO
-
-from invoke.vendor.six import text_type, binary_type, PY2
+from invoke.vendor.six import PY2
 from invoke.vendor.lexicon import Lexicon
 
 from blessings import Terminal
@@ -481,7 +480,7 @@ def _release_and_issues(changelog, branch, release_type):
     release = None
     # And requires scanning changelog, for bugfix lines
     if release_type is Release.BUGFIX:
-        versions = [text_type(x) for x in _versions_from_changelog(changelog)]
+        versions = [str(x) for x in _versions_from_changelog(changelog)]
         release = [x for x in versions if x.startswith(bucket)][-1]
     return release, issues
 
@@ -574,8 +573,7 @@ def load_version(c):
     sys.modules.pop(package_name, None)
     # NOTE: have to explicitly give it a bytestr (Python 2) or unicode (Python
     # 3) because https://bugs.python.org/issue21720 HOORAY
-    cast = binary_type if PY2 else text_type
-    package = __import__(package_name, fromlist=[cast(version_module)])
+    package = __import__(package_name, fromlist=[str(version_module)])
     # TODO: explode nicely if it lacks a _version/etc, or a __version__
     # TODO: make this a Version()?
     return getattr(package, version_module).__version__
@@ -828,11 +826,6 @@ def test_install(c, directory, verbose=False):
 
     Uses the `venv` module to build temporary virtualenvs.
     """
-    # TODO: streamline all this in 3.0 when we drop all Py2 support both here
-    # and in downstream repos
-    if PY2:
-        print("WARNING: skipping installation test due to no venv on Python 2")
-        return
     import venv
 
     # TODO: wants contextmanager or similar for only altering a setting within

--- a/invocations/packaging/release.py
+++ b/invocations/packaging/release.py
@@ -21,7 +21,6 @@ from glob import glob
 from io import StringIO
 from shutil import rmtree
 
-from invoke.vendor.six import PY2
 from invoke.vendor.lexicon import Lexicon
 
 from blessings import Terminal

--- a/invocations/packaging/semantic_version_monkey.py
+++ b/invocations/packaging/semantic_version_monkey.py
@@ -4,9 +4,6 @@ Monkey patches for ``semantic_version.Version``.
 We never like monkey-patching, but for now this is easier than either vendoring
 or distributing our own fork.
 """
-
-from invoke.vendor.six import text_type
-
 from semantic_version import Version
 
 
@@ -17,7 +14,7 @@ def clone(self):
     Useful when you need to generate a new object that can be mutated
     separately from the original.
     """
-    return Version(text_type(self))
+    return Version(str(self))
 
 
 Version.clone = clone

--- a/invocations/testing.py
+++ b/invocations/testing.py
@@ -1,8 +1,6 @@
 import sys
 import time
 from collections import defaultdict
-from invoke.vendor.six import iteritems
-from invoke.vendor.six.moves import range
 
 from invoke import task
 from tqdm import tqdm
@@ -164,7 +162,7 @@ def count_errors(c, command, trials=10, verbose=False, fail_fast=False):
     counts = defaultdict(int)
     for period in periods:
         counts[period] += 1
-    mode = sorted((value, key) for key, value in iteritems(counts))[-1][1]
+    mode = sorted((value, key) for key, value in counts.items())[-1][1]
     # Emission of stats!
     if fail_fast:
         print("First failure occurred after {} successes".format(successes))

--- a/tests/packaging/release.py
+++ b/tests/packaging/release.py
@@ -5,7 +5,6 @@ from os import path
 import re
 import sys
 
-from invoke.vendor.six import PY2
 from invoke.vendor.lexicon import Lexicon
 from invoke import MockContext, Result, Config, Exit
 from docutils.utils import Reporter
@@ -308,10 +307,8 @@ def _mock_context(self):
             return real_import(*args, **kwargs)
         return Mock(_version=Mock(__version__=self._version))
 
-    # Because I can't very well patch six.moves.builtins itself, can I? =/
-    builtins = "__builtin__" if PY2 else "builtins"
     import_patcher = patch(
-        "{}.__import__".format(builtins), side_effect=fake_import
+        "{}.__import__".format("builtins"), side_effect=fake_import
     )
 
     with import_patcher:


### PR DESCRIPTION
Python 2 has been deprecated for over a year now. This pull request removes integrations with invoke with six that are used to support now deprecated Python2 compatibility. Removing this will allow builds to be more simplified while allow integration with more modern tooling from the Python ecosystem.

see corresponding: https://github.com/pyinvoke/invoke/pull/856