### PR TITLE
FIX: Loosen version pin on tabulate package

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ pytest-cov==2.4.0
 pytest-mock==3.2.0
 watchdog==0.8.3
 coverage==4.4.2
-codecov==2.1.11
+codecov==2.1.13
 # Formatting
 black==19.10b0
 # Linting

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "blessings>=1.6",
     "releases>=1.6",
     "semantic_version>=2.4,<2.7",
-    "tabulate==0.7.5",
+    "tabulate>=0.7.5",
     "tqdm>=4.8.1",
     "twine>=1.15",
     "wheel>=0.24.0",


### PR DESCRIPTION
This PR loosens a too restrictive version pin on the tabulate package too allow invocations to be used in projects that use: 

* databricks-cli, depends on tabulate tabulate (>=0.7.7)
* django-query-capture, depends on tabulate (>=0.8.9,<0.9.0)

`invocations` makes very basic use of tabulate in a single place: https://github.com/pyinvoke/invocations/blob/8a693df9b5fd2283cfb460cb44f66714bc83e3fb/invocations/packaging/release.py#L276 which should not be impacted by a newer version.