### PR TITLE
Adjust to cope with Sphinx 9

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ html_sidebars = {
 }
 
 # Other extension configs
+autodoc_use_legacy_class_based = True
 autodoc_default_options = {
     "members": True,
     "special-members": True,

--- a/invocations/autodoc.py
+++ b/invocations/autodoc.py
@@ -26,6 +26,9 @@ To use:
 
     - As noted above, this only works for modules that are importable, like any
       other Sphinx autodoc use case.
+    - For now, add ``autodoc_use_legacy_class_based = True`` to your
+      ``conf.py`` (see `sphinx-doc/sphinx#14089
+      <https://github.com/sphinx-doc/sphinx/issues/14089>`__).
     - Unless you want to opt-in which module members get documented, use
       ``:members:`` or add ``"members": True`` to your ``conf.py``'s
       ``autodoc_default_options``.
@@ -47,6 +50,7 @@ from invoke import Task
 
 # For sane mock patching. Meh.
 from sphinx.ext import autodoc
+from sphinx.util.inspect import stringify_signature
 
 
 class TaskDocumenter(
@@ -68,7 +72,7 @@ class TaskDocumenter(
         # after which point "call tasks as raw functions" may be less common.
         # TODO: also, it may become moot-ish if we turn this all into emission
         # of custom domain objects and/or make the CLI arguments the focus
-        return autodoc.stringify_signature(inspect.signature(function))
+        return stringify_signature(inspect.signature(function))
 
     def document_members(self, all_members=False):
         # Neuter this so superclass bits don't introspect & spit out autodoc

--- a/tests/autodoc/_support/conf.py
+++ b/tests/autodoc/_support/conf.py
@@ -7,4 +7,5 @@ sys.path.insert(0, dirname(__file__))
 
 master_doc = "index"
 extensions = ["invocations.autodoc"]
+autodoc_use_legacy_class_based = True
 autodoc_default_options = dict(members=True)


### PR DESCRIPTION
There might be some way to make this extension work with the new `sphinx.ext.autodoc` implementation, but if so I don't know what it is; see https://github.com/sphinx-doc/sphinx/issues/14089.  For now, this seems to get things going again.

`sphinx.ext.autodoc.stringify_signature` was only ever a re-export from `sphinx.util.inspect`, so importing it directly from there should be safe with all the Sphinx versions that worked before.